### PR TITLE
Support user authentication (internal use only)

### DIFF
--- a/examples/simple/src/pages/api/source-token.ts
+++ b/examples/simple/src/pages/api/source-token.ts
@@ -2,14 +2,15 @@ import { TokenGenerator } from '@source-health/source-js/server'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 const generator = new TokenGenerator(
-  process.env.SOURCE_KEY_ID || '',
-  process.env.SOURCE_KEY_SECRET || '',
+  process.env.SOURCE_KEY_ID || 'key_YYc96gyopG0klWfUOhQU',
+  process.env.SOURCE_KEY_SECRET ||
+    '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',
 )
 
 export default function (_req: NextApiRequest, res: NextApiResponse) {
   res.json({
     token: generator.generate({
-      member: process.env.SOURCE_MEMBER_ID || '',
+      member: process.env.SOURCE_MEMBER_ID || 'mem_519zW7gVTy19LS9uDQAe',
       expiration: new Date(Date.now() + 24 * 60 * 60 * 1000),
       scopes: [],
     }),

--- a/examples/simple/src/pages/api/source-token.ts
+++ b/examples/simple/src/pages/api/source-token.ts
@@ -2,15 +2,14 @@ import { TokenGenerator } from '@source-health/source-js/server'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 const generator = new TokenGenerator(
-  process.env.SOURCE_KEY_ID || 'key_YYc96gyopG0klWfUOhQU',
-  process.env.SOURCE_KEY_SECRET ||
-    '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',
+  process.env.SOURCE_KEY_ID || '',
+  process.env.SOURCE_KEY_SECRET || '',
 )
 
 export default function (_req: NextApiRequest, res: NextApiResponse) {
   res.json({
     token: generator.generate({
-      member: process.env.SOURCE_MEMBER_ID || 'mem_519zW7gVTy19LS9uDQAe',
+      member: process.env.SOURCE_MEMBER_ID || '',
       expiration: new Date(Date.now() + 24 * 60 * 60 * 1000),
       scopes: [],
     }),

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "packages": [
     "packages/*"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-health/source-js",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "license": "MIT",
   "description": "TypeScript SDK for building modern, Source-powered patient experiences",
   "private": false,

--- a/packages/core/src/SourceConfiguration.ts
+++ b/packages/core/src/SourceConfiguration.ts
@@ -1,6 +1,9 @@
 import { BaseEmitter } from '@source-health/js-bridge'
 
-import type { Authentication } from './authentication/Authentication'
+import type {
+  Authentication,
+  AuthenticationToken,
+} from './authentication/Authentication'
 import type { Appearance } from './types'
 
 export interface SourceConfigurationOptions {
@@ -56,7 +59,7 @@ export class SourceConfiguration extends BaseEmitter<SourceConfigurationEvents> 
     return this.options.appearance ?? {}
   }
 
-  public getToken(): Promise<string | null> {
+  public getToken(): Promise<AuthenticationToken | string | null> {
     return this.options.authentication.token()
   }
 }

--- a/packages/core/src/authentication/Authentication.ts
+++ b/packages/core/src/authentication/Authentication.ts
@@ -1,3 +1,8 @@
+export interface AuthenticationToken {
+  token: string
+  testMode?: boolean
+}
+
 export interface Authentication {
   /**
    * Returns a promise that will be resolved when a token is made available
@@ -5,5 +10,5 @@ export interface Authentication {
    * Implementations are free to generate tokens however they'd like. If no token is available, this
    * method should return null.
    */
-  token(): Promise<string | null>
+  token(): Promise<AuthenticationToken | string | null>
 }

--- a/packages/core/src/elements/FormElement.ts
+++ b/packages/core/src/elements/FormElement.ts
@@ -20,6 +20,11 @@ export interface FormOptions {
    * Provide a formId (or key) into the frame
    */
   form: string
+
+  /**
+   * Provide whether the form is in preview mode into the frame
+   */
+  preview?: boolean
 }
 
 export class FormElement extends SourceElement<FormOptions, FormEvents> {

--- a/packages/core/src/elements/FormElement.ts
+++ b/packages/core/src/elements/FormElement.ts
@@ -22,7 +22,10 @@ export interface FormOptions {
   form: string
 
   /**
-   * Provide whether the form is in preview mode into the frame
+   * Whether to render the form in preview mode. When running in preview mode, forms will
+   * render the latest saved version, not necessarily the last published version. Additionally,
+   * when running in preview mode, form flows will process as usual but responses will not be
+   * submitted.
    */
   preview?: boolean
 }


### PR DESCRIPTION
To support form previewing without a member in the Clinical UI, we granted users access to the Experience API. With that change, we also need to support user authentication here in souce-js. Instead of modifying any of the current authentication types, we're just allowing an additional authentication object that's passed through.

This is an undocumented change as it's only for internal use.